### PR TITLE
Update gthumb source version to 3.12.10

### DIFF
--- a/snapcraft.yaml
+++ b/snapcraft.yaml
@@ -38,7 +38,7 @@ apps:
 
 parts:
   main:
-    source: https://download.gnome.org/sources/gthumb/3.12/gthumb-3.12.8.tar.xz
+    source: https://download.gnome.org/sources/gthumb/3.12/gthumb-3.12.10.tar.xz
     plugin: meson
     meson-parameters: [--prefix=/usr]
 


### PR DESCRIPTION
Commit 9b8bb67 only updated the version of the Snap itself, but did not update the URL of the source tarball. This means that the version is inconsistent between the Snap itself and the actual installed program:

```console
$ snap list | grep gthumb
gthumb-unofficial    3.12.10    27    latest/stable    nbuechner    -
```

<img width="476" height="393" alt="About dialog of gThumb showing version 3.12.8" src="https://github.com/user-attachments/assets/6f22e364-99dc-4d7d-b8e6-a522f6c8e5e4" />

This PR syncs the version of the source tarball to match the Snap version.